### PR TITLE
Fix license to contain correct copyright information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 Protocol Labs Inc.
-Copyright (c) 2018-2019 Haja Networks Oy
+Copyright (c) 2017-2019 Haja Networks Oy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ Please note that all interactions in [@OrbitDB](https://github.com/OrbitDB) fall
 
 ## License
 
-[MIT](LICENSE) © 2016-2018 Protocol Labs Inc., 2018-2019 Haja Networks Oy
+[MIT](LICENSE) © 2017-2019 Haja Networks Oy


### PR DESCRIPTION
This PR will remove Protocol Labs from license information and change the year to the correct creation year.

I believe PL was added along with the readme sweep in all repos. However, this module was not done under PL and was under my copyright until Haja Networks.

The module was also started in 2017 and not 2016 as it previously stated.