### PR TITLE
chore: Add npm maintainers

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "test": "./node_modules/.bin/mocha",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha"
   },
-  "maintainer": [
-    "haad <haad@headbanggames.com>"
-  ]
+  "orbitdb": {
+    "maintainer": [
+      "haad <haad@headbanggames.com>",
+      "shamb0t <shams.methnani@gmail.com>"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "orbitdb": {
     "maintainer": [
-      "haad <haad@headbanggames.com>",
+      "haad <haad@haja.io>",
       "shamb0t <shams.methnani@gmail.com>"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "scripts": {
     "test": "./node_modules/.bin/mocha",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha"
-  }
+  },
+  "maintainer": [
+    "haad <haad@headbanggames.com>"
+  ]
 }


### PR DESCRIPTION
This adds a maintainers field to the package.json. Ideally, someone else should be in this field, too. Please add another contributor as a maintainer for this npm package, such as @shamb0t, by typing: `npm owner add @shamb0t`. Then, add them to the maintainers field in this PR, or ping me to do it. Thank you.