### PR TITLE
Add Github Action to publish an rc version to npm

### DIFF
--- a/.github/workflows/npm-publish-next.yml
+++ b/.github/workflows/npm-publish-next.yml
@@ -1,0 +1,25 @@
+---
+name: Node.js Package (next tag)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm test
+      - run: |
+          npm version prerelease --no-git-tag-version \
+            --preid=`git rev-parse --short HEAD`
+          npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
This PR adds a Github Action to publish an RC version to npm upon pushing changes to main branch.